### PR TITLE
refactor: Order And Sort 쿼리 파라미터 값 enum class로 관리

### DIFF
--- a/src/main/java/com/ssafy/enjoycamping/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/ssafy/enjoycamping/common/exception/ExceptionAdvice.java
@@ -31,7 +31,7 @@ public class ExceptionAdvice {
         return new BaseResponse<>(exception.getStatus());
     }
 
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class, IllegalArgumentException.class})
     @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터 타입", content = @Content)
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public BaseResponse<BaseResponseStatus> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {

--- a/src/main/java/com/ssafy/enjoycamping/common/util/PagingAndSorting.java
+++ b/src/main/java/com/ssafy/enjoycamping/common/util/PagingAndSorting.java
@@ -1,5 +1,7 @@
 package com.ssafy.enjoycamping.common.util;
 
+import com.ssafy.enjoycamping.common.exception.BadRequestException;
+import com.ssafy.enjoycamping.common.response.BaseResponseStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,16 +10,16 @@ import lombok.Setter;
 public class PagingAndSorting {
     private int pageNo;
     private int pageCnt;
-    private String order;
-    private String sort;
     private int offset;
+    private Order order;
+    private Sort sort;
 
-    public PagingAndSorting(int pageNo, int pageCnt, String order, String sort) {
+    public PagingAndSorting(int pageNo, int pageCnt, Order order, Sort sort) {
         this.pageNo = pageNo;
         this.pageCnt = pageCnt;
+        this.offset = (pageNo - 1) * pageCnt; // Offset 계산
         this.order = order;
         this.sort = sort;
-        this.offset = (pageNo - 1) * pageCnt; // Offset 계산
     }
 
     public PagingAndSorting(int pageNo, int pageCnt) {
@@ -25,4 +27,23 @@ public class PagingAndSorting {
         this.pageCnt = pageCnt;
         this.offset = (pageNo - 1) * pageCnt; // Offset 계산
     }
+
+    public interface Order {}
+    public enum CampingOrder implements Order {
+        name;
+    }
+    public enum AttractionOrder implements Order {
+        title;
+    }
+    public enum ReviewOrder implements Order {
+        created_at;
+    }
+    public enum DistanceOrder implements Order {
+        distance;
+    }
+
+    public enum Sort {
+        asc, desc;
+    }
+
 }

--- a/src/main/java/com/ssafy/enjoycamping/review/controller/ReviewController.java
+++ b/src/main/java/com/ssafy/enjoycamping/review/controller/ReviewController.java
@@ -37,7 +37,6 @@ public class ReviewController {
 		this.reviewService = reviewService;
 	}
 
-
 	@PostMapping
 	public BaseResponse<CreateReviewDto.ResponseCreateReviewDto> createReview(@RequestBody CreateReviewDto.RequestCreateReviewDto request) {
 		CreateReviewDto.ResponseCreateReviewDto response = reviewService.createReview(request);
@@ -80,10 +79,10 @@ public class ReviewController {
 			@RequestParam(value = "keyword", required = false) String keyword,
 			@RequestParam(value = "sido", required = false) String sido,
 			@RequestParam(value = "gugun", required = false) String gugun,
-			@RequestParam(defaultValue = "0") int pageNo,
-            @RequestParam(defaultValue = "10") int pageCnt,
-            @RequestParam(defaultValue = "id") String order,
-            @RequestParam(defaultValue = "asc") String sort) {
+			@RequestParam(defaultValue = "1") int pageNo,
+            @RequestParam(defaultValue = "5") int pageCnt,
+            @RequestParam(defaultValue = "created_at") PagingAndSorting.ReviewOrder order,
+            @RequestParam(defaultValue = "desc") PagingAndSorting.Sort sort) {
 		PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
 		List<ReviewDto> reviews = reviewService.searchReviews(keyword, sido, gugun, pagingAndSorting);
 		return new BaseResponse<>(reviews);

--- a/src/main/java/com/ssafy/enjoycamping/trip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/ssafy/enjoycamping/trip/attraction/controller/AttractionController.java
@@ -41,11 +41,11 @@ public class AttractionController {
             @RequestParam(value = "contentType", required = false) List<Integer> contentType,
             @RequestParam(defaultValue = "1") int pageNo,
             @RequestParam(defaultValue = "9") int pageCnt,
-            @RequestParam(defaultValue = "title") String order,
-            @RequestParam(defaultValue = "asc") String sort){
+            @RequestParam(defaultValue = "title") PagingAndSorting.AttractionOrder order,
+            @RequestParam(defaultValue = "asc") PagingAndSorting.Sort sort){
         PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
         List<AttractionDto> attractions = attractionService.searchAttractions(keyword, sidoCode, gugunCode, contentType, pagingAndSorting);
-        int totalCount = attractionService.countByCondition(keyword, sidoCode, gugunCode);
+        int totalCount = attractionService.countByCondition(keyword, sidoCode, gugunCode, contentType);
 
         return new BaseResponse<>(attractions, totalCount);
     }
@@ -57,8 +57,10 @@ public class AttractionController {
     public BaseResponse<List<AttractionDistanceDto>> getNearByCampsite(
             @PathVariable("index") int index,
             @RequestParam(defaultValue = "1") int pageNo,
-            @RequestParam(defaultValue = "9") int pageCnt){
-        PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt);
+            @RequestParam(defaultValue = "9") int pageCnt,
+            @RequestParam(defaultValue = "distance") PagingAndSorting.DistanceOrder order,
+            @RequestParam(defaultValue = "asc") PagingAndSorting.Sort sort){
+        PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
         List<AttractionDistanceDto> attractions = attractionService.getNearByCampsite(index, pagingAndSorting);
         int totalCount = attractionService.countInSameGugun(index);
 

--- a/src/main/java/com/ssafy/enjoycamping/trip/attraction/dao/AttractionDao.java
+++ b/src/main/java/com/ssafy/enjoycamping/trip/attraction/dao/AttractionDao.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface AttractionDao {
 	Optional<Attraction> selectById(int id);
 	List<Attraction> selectByCondition(String keyword, Integer sidoCode, Integer gugunCode, List<Integer> contentTypeId, PagingAndSorting pagingAndSorting);
-	int countByCondition(String keyword, Integer sidoCode, Integer gugunCode);
+	int countByCondition(String keyword, Integer sidoCode, Integer gugunCode, List<Integer> contentType);
 	List<AttractionDistanceDto> selectAttractionsInSameGugun(int campingId, PagingAndSorting pagingAndSorting);
 	int countInSameGugun(int attractionId);
 }

--- a/src/main/java/com/ssafy/enjoycamping/trip/attraction/service/AttractionService.java
+++ b/src/main/java/com/ssafy/enjoycamping/trip/attraction/service/AttractionService.java
@@ -9,7 +9,6 @@ import com.ssafy.enjoycamping.trip.attraction.dto.AttractionDistanceDto;
 import com.ssafy.enjoycamping.trip.attraction.dto.AttractionDto;
 import com.ssafy.enjoycamping.trip.attraction.entity.Attraction;
 import com.ssafy.enjoycamping.trip.camping.dao.CampingDao;
-import com.ssafy.enjoycamping.trip.camping.entity.Camping;
 import com.ssafy.enjoycamping.trip.contenttype.dao.ContentTypeDao;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,8 +45,8 @@ public class AttractionService {
 				.collect(Collectors.toList());
 	}
 
-	public int countByCondition(String keyword, Integer sidoCode, Integer gugunCode) {
-		return attractionDao.countByCondition(keyword, sidoCode, gugunCode);
+	public int countByCondition(String keyword, Integer sidoCode, Integer gugunCode, List<Integer> contentType) {
+		return attractionDao.countByCondition(keyword, sidoCode, gugunCode, contentType);
 	}
 
 	public List<AttractionDistanceDto> getNearByCampsite(int campingId, PagingAndSorting pagingAndSorting) throws BaseException {

--- a/src/main/java/com/ssafy/enjoycamping/trip/camping/controller/CampingController.java
+++ b/src/main/java/com/ssafy/enjoycamping/trip/camping/controller/CampingController.java
@@ -40,8 +40,8 @@ public class CampingController {
             @RequestParam(value = "gugun", required = false) Integer gugunCode,
             @RequestParam(defaultValue = "1") int pageNo,
             @RequestParam(defaultValue = "9") int pageCnt,
-            @RequestParam(defaultValue = "name") String order,
-            @RequestParam(defaultValue = "asc") String sort){
+            @RequestParam(defaultValue = "name") PagingAndSorting.CampingOrder order,
+            @RequestParam(defaultValue = "asc") PagingAndSorting.Sort sort){
         PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
         List<CampingDto> campings = campingService.searchCampings(keyword, sidoCode, gugunCode, pagingAndSorting);
         int totalCount = campingService.countByCondition(keyword, sidoCode, gugunCode);
@@ -56,8 +56,10 @@ public class CampingController {
     public BaseResponse<List<CampingDistanceDto>> getNearByCampsite(
             @PathVariable("index") int index,
             @RequestParam(defaultValue = "1") int pageNo,
-            @RequestParam(defaultValue = "9") int pageCnt){
-        PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt);
+            @RequestParam(defaultValue = "9") int pageCnt,
+            @RequestParam(defaultValue = "distance") PagingAndSorting.DistanceOrder order,
+            @RequestParam(defaultValue = "asc") PagingAndSorting.Sort sort){
+        PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
         List<CampingDistanceDto> campings = campingService.getNearByAttraction(index, pagingAndSorting);
         int totalCount = campingService.countInSameGugun(index);
 

--- a/src/main/resources/mapper/attraction-mapper.xml
+++ b/src/main/resources/mapper/attraction-mapper.xml
@@ -104,10 +104,10 @@
         <if test="gugunCode != null and gugunCode != ''">
             AND si_gun_gu_code = #{gugunCode}
         </if>
-        <if test="contentTypeId != null and !contentTypeId.isEmpty()">
+        <if test="contentType != null and !contentType.isEmpty()">
             AND content_type_id IN
-            <foreach item="typeId" collection="contentTypeId" open="(" separator="," close=")">
-                #{typeId}
+            <foreach item="contentTypeId" collection="contentType" open="(" separator="," close=")">
+                #{contentTypeId}
             </foreach>
         </if>
     </select>
@@ -127,7 +127,16 @@
         JOIN camping c ON c.id = #{campingId}
         WHERE a.area_code = c.sido_code
         AND a.si_gun_gu_code = c.gugun_code
-        ORDER BY distance ASC
+
+        <!-- 동적 정렬 처리 -->
+        <choose>
+            <when test="pagingAndSorting.order != null and pagingAndSorting.sort != null">
+                ORDER BY ${pagingAndSorting.order} ${pagingAndSorting.sort}
+            </when>
+            <otherwise>
+                ORDER BY distance ASC  <!-- 기본 정렬 조건 설정 -->
+            </otherwise>
+        </choose>
 
         <!-- 페이징 처리 -->
         <if test="pagingAndSorting.pageCnt > 0">

--- a/src/main/resources/mapper/camping-mapper.xml
+++ b/src/main/resources/mapper/camping-mapper.xml
@@ -109,7 +109,16 @@
         JOIN attractions a ON a.no = #{attractionId}
         WHERE a.area_code = c.sido_code
         AND a.si_gun_gu_code = c.gugun_code
-        ORDER BY distance ASC
+
+        <!-- 동적 정렬 처리 -->
+        <choose>
+            <when test="pagingAndSorting.order != null and pagingAndSorting.sort != null">
+                ORDER BY ${pagingAndSorting.order} ${pagingAndSorting.sort}
+            </when>
+            <otherwise>
+                ORDER BY distance ASC  <!-- 기본 정렬 조건 설정 -->
+            </otherwise>
+        </choose>
 
         <!-- 페이징 처리 -->
         <if test="pagingAndSorting.pageCnt > 0">


### PR DESCRIPTION
# 🚀 Pull Request

### 📝 작성한 기능
- Order And Sort 쿼리 파라미터 값 enum class로 관리
- 서버에서 정해둔 enum value가 아니라면 `INVALID_PARAMETER` 에러 발생

### 💬 Comment
```java
package com.ssafy.enjoycamping.common.util;

import com.ssafy.enjoycamping.common.exception.BadRequestException;
import com.ssafy.enjoycamping.common.response.BaseResponseStatus;
import lombok.Getter;
import lombok.Setter;

@Getter
@Setter
public class PagingAndSorting {
    // 생략
    public interface Order {}
    public enum CampingOrder implements Order {
        name;
    }
    public enum AttractionOrder implements Order {
        title;
    }
    public enum ReviewOrder implements Order {
        created_at;
    }
    public enum DistanceOrder implements Order {
        distance;
    }
    public enum Sort {
        asc, desc;
    }
}

```

```java
 @GetMapping("/campings/{index}")
    public BaseResponse<List<AttractionDistanceDto>> getNearByCampsite(
            @PathVariable("index") int index,
            @RequestParam(defaultValue = "1") int pageNo,
            @RequestParam(defaultValue = "9") int pageCnt,
            @RequestParam(defaultValue = "distance") PagingAndSorting.DistanceOrder order,
            @RequestParam(defaultValue = "asc") PagingAndSorting.Sort sort){
        PagingAndSorting pagingAndSorting = new PagingAndSorting(pageNo, pageCnt, order, sort);
        List<AttractionDistanceDto> attractions = attractionService.getNearByCampsite(index, pagingAndSorting);
        int totalCount = attractionService.countInSameGugun(index);

        return new BaseResponse<>(attractions, totalCount);
    }
```

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/7a7c3e05-2f48-4761-ad69-627b96c809c0)