### PR TITLE
refactor: JwtProvider 수정 및 메서드 수정에 따른 호출 부분 수정

### DIFF
--- a/src/main/java/com/ssafy/enjoycamping/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/enjoycamping/auth/JwtAuthenticationFilter.java
@@ -78,7 +78,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             handleRefreshToken(refreshToken.get(), response);
         } 
         else {
-            //accessToken과 refreshToken 둘 다 없는 경우
+        	//accessToken과 refreshToken 둘 다 없는 경우
             response.setStatus(HttpServletResponse.SC_OK);
         }
         filterChain.doFilter(request, response);
@@ -91,10 +91,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         	case VALID -> { //refreshToken 유효한 경우
         		String userId = String.valueOf(parsedRefreshToken.getClaims().get("id"));
                 // Redis에 저장된 Refresh Token과 비교
-                String storedToken = jwtProvider.getStoredRefreshToken(Integer.parseInt(userId));
-                if (refreshToken.equals(storedToken)) {
+                if(jwtProvider.checkStoredRefreshToken(userId, refreshToken)) {
                     issueNewTokens(response, userId);
-                    log.info("accessToken이 갱신됨");
+                    log.warn("accessToken이 갱신됨");
                     Authentication authentication = jwtProvider.getAuthentication(userId);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } 
@@ -112,7 +111,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         	}
         } 
-        
     }
 	
 	private Optional<String> getTokenFromCookie(HttpServletRequest request, String tokenName) {

--- a/src/main/java/com/ssafy/enjoycamping/user/service/UserService.java
+++ b/src/main/java/com/ssafy/enjoycamping/user/service/UserService.java
@@ -123,7 +123,7 @@ public class UserService {
 	}
 
 	public ModifyPwdDto.ResponseModifyPwdDto modifyPassword(ModifyPwdDto.RequestModifyPwdDto request) throws BaseException {
-		int id = jwtProvider.getAuthenticatedUserId(TokenType.ACCESS);
+		int id = jwtProvider.getAuthenticatedUserId();
 
 		// JWT로 User 불러오기
 		User user = userDao.selectActiveById(id)
@@ -144,7 +144,7 @@ public class UserService {
 	}
 
 	public void logout() throws BaseException {
-		int id = jwtProvider.getAuthenticatedUserId(TokenType.ACCESS);
+		int id = jwtProvider.getAuthenticatedUserId();
 
 		// JWT로 User 불러오기
 		User user = userDao.selectActiveById(id)
@@ -154,7 +154,7 @@ public class UserService {
 	}
 
 	public void withdraw() throws BaseException {
-		int id = jwtProvider.getAuthenticatedUserId(TokenType.ACCESS);
+		int id = jwtProvider.getAuthenticatedUserId();
 
 		// JWT로 User 불러오기
 		User user = userDao.selectActiveById(id)


### PR DESCRIPTION
# 🚀 Pull Request

### 📝 작성한 기능
- JwtProvider에서 쓰지 않는 메서드들 삭제
- JwtProvider getAuthenticatedUserId메서드 수정

### 💬 Comment
- JwtProvider에서 필요없는 메서드들 삭제
- JwtProvider의 getAuthenticatedUserId메서드가 Request Header에서 토큰을 가져오는 부분 쿠키에서 가져오도록 수정
- 쿠키에서 토큰을 가져옴에 따라 TokenType을 명시하지 않아도 되었기에 UserService에서 getAuthenticatedUserId호출 부분 수정
